### PR TITLE
Range speedup

### DIFF
--- a/Basic/Slices/slices.pd
+++ b/Basic/Slices/slices.pd
@@ -409,10 +409,9 @@ pp_addpm(<<'EOD-range');
 
 sub PDLA::range {
   my($source,$ind,$sz,$bound) = @_;
-  my $index = PDLA->pdl($ind);
-
+  # Convert to indx type up front (also handled in rangeb if necessary)
+  my $index = (ref $ind && UNIVERSAL::isa($ind,'PDLA') && $ind->type eq 'indx') ? $ind : indx($ind);
   my $size = defined($sz) ? PDLA->pdl($sz) : undef;
-
 
   # Handle empty PDLA case: return a properly constructed Empty.
   if($index->isempty) {
@@ -783,7 +782,7 @@ switch(ind_pdl->datatype) {
    PDLA->converttype(&ind_pdl,PDLA_IND,1); /* convert in place. */
    break;
  case PDLA_IND:
-   /* do nothing */
+   PDLA->make_physical(ind_pdl);
    break;
 }
 
@@ -890,6 +889,7 @@ switch(ind_pdl->datatype) {
         PDLA->converttype(&size_pdl,PDLA_IND,1); /* convert in place. */
         break;
       case PDLA_IND:
+        PDLA->make_physical(size_pdl);
         break;
       }
 
@@ -1083,7 +1083,11 @@ EOD-RedoDims
           if(ck < 0 || ck >= $PARENT_P(dims[k])) {
             switch($COMP(boundary[k])) {
             case 0: /* no boundary breakage allowed */
-              barf("index out-of-bounds in range");
+	      {
+		char barfstr[1024];
+		sprintf(barfstr,"index out-of-bounds in range (index vector #%ld)",item);
+		barf(barfstr);
+	      }
               break;
             case 1: /* truncation */
               trunc = 1;


### PR DESCRIPTION
@drzowie :

> Speeds up range by 20%-50% depending on use pattern, just by not copying the index variable extra times.

His branch had as a previous commit the change in #4 which I have removed to keep separate, so there will need to be careful checking these changes are independent.
